### PR TITLE
v2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdklib",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "JDK utility library",
   "main": "./dist/index.js",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",
@@ -23,13 +23,13 @@
   },
   "dependencies": {
     "appcd-fs": "^0.1.0",
+    "appcd-logger": "^0.1.0",
     "appcd-path": "^0.1.0",
     "appcd-subprocess": "^0.1.0",
-    "snooplogg": "^1.8.0",
     "source-map-support": "^0.5.0"
   },
   "devDependencies": {
-    "appcd-gulp": "^0.1.2",
+    "appcd-gulp": "^0.1.3",
     "gulp": "^3.9.1"
   },
   "homepage": "https://github.com/appcelerator/jdklib",

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,14 @@ if (!Error.prepareStackTrace) {
 }
 
 import path from 'path';
-import snooplogg from 'snooplogg';
+import appcdLogger from 'appcd-logger';
 
 import { isDir, isFile } from 'appcd-fs';
 import { expandPath, real } from 'appcd-path';
 import { exe, run } from 'appcd-subprocess';
 
-const { log } = snooplogg.config({ theme: 'detailed' })('jdklib');
-const { highlight } = snooplogg.styles;
+const { log } = appcdLogger('jdklib');
+const { highlight } = appcdLogger.styles;
 
 const re = /^javac (.+?)(?:_(.+))?$/;
 

--- a/test/mocks/jdk-9-darwin/Contents/Home/bin/java
+++ b/test/mocks/jdk-9-darwin/Contents/Home/bin/java
@@ -1,0 +1,4 @@
+#!/bin/sh
+>&2 echo "java version \"9.0.1\""
+>&2 echo "Java(TM) SE Runtime Environment (build 9.0.1+11)"
+>&2 echo "Java HotSpot(TM) 64-Bit Server VM (build 9.0.1+11, mixed mode)"

--- a/test/mocks/jdk-9-darwin/Contents/Home/bin/javac
+++ b/test/mocks/jdk-9-darwin/Contents/Home/bin/javac
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "javac 9"
+echo "javac 9.0.1"

--- a/test/mocks/jdk-9/bin/java
+++ b/test/mocks/jdk-9/bin/java
@@ -1,0 +1,4 @@
+#!/bin/sh
+>&2 echo "java version \"9\""
+>&2 echo "Java(TM) SE Runtime Environment (build 9+181)"
+>&2 echo "Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)"

--- a/test/test-jdk.js
+++ b/test/test-jdk.js
@@ -151,7 +151,7 @@ describe('JDK', () => {
 		return detect(dir)
 			.then(jdk => {
 				expect(jdk.arch).to.equal('64bit');
-				expect(jdk.build).to.equal(181);
+				expect(jdk.build).to.equal(11);
 				expect(jdk.executables).to.deep.equal({
 					java:      path.join(dir, 'Contents', 'Home', 'bin', 'java' + exe),
 					javac:     path.join(dir, 'Contents', 'Home', 'bin', 'javac' + exe),
@@ -159,7 +159,7 @@ describe('JDK', () => {
 					jarsigner: path.join(dir, 'Contents', 'Home', 'bin', 'jarsigner' + exe)
 				});
 				expect(jdk.path).to.equal(path.join(dir, 'Contents', 'Home'));
-				expect(jdk.version).to.equal('1.8.0');
+				expect(jdk.version).to.equal('9.0.1');
 			});
 	});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,9 +109,9 @@ appcd-fs@0.1.0, appcd-fs@^0.1.0:
   dependencies:
     source-map-support "^0.4.16"
 
-appcd-gulp@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/appcd-gulp/-/appcd-gulp-0.1.2.tgz#c6b0d9b2fd55278abfd4410078803d346538f705"
+appcd-gulp@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/appcd-gulp/-/appcd-gulp-0.1.3.tgz#21d50e5b75c562da1ba1a452b1aaacb7c9da9ae6"
   dependencies:
     babel-eslint "^8.0.1"
     babel-plugin-dynamic-import-node "^1.1.0"
@@ -146,7 +146,7 @@ appcd-gulp@^0.1.1:
     sinon "^4.0.1"
     sinon-chai "^2.14.0"
 
-appcd-logger@0.1.0:
+appcd-logger@0.1.0, appcd-logger@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/appcd-logger/-/appcd-logger-0.1.0.tgz#f4bf70c87560fcf7f09a4c7eb9cbd007b4f3f4ed"
   dependencies:


### PR DESCRIPTION
Fixed up JDK 9 unit tests for macOS.

Switched from snooplogg to appcd-logger.