### PR TITLE
Run unit tests across Linux, OSX and Windows using Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules
 npm-debug.log
 yarn-error.log
+junit.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ timestamps {
       isMaster = env.BRANCH_NAME.equals('master')
       packageVersion = jsonParse(readFile('package.json'))['version']
       currentBuild.displayName = "#${packageVersion}-${currentBuild.number}"
-      stash name: 'sources', includes: '**', allowEmpty: true
+      stash allowEmpty: true, name: 'sources', useDefaultExcludes: false
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,75 @@
+#! groovy
+library 'pipeline-library'
+// TODO: Could we make this an array and test across multiple major versions
+def nodeVersion = '8.9.1'
+
+def unitTests(os, nodeVersion) {
+  return {
+    node(os) {
+      nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
+        stage('Test') {
+          timeout(15) {
+            unstash 'sources'
+            // Install yarn if not installed
+            if('windows'.equals(os)) {
+              if (bat(returnStatus: true, script: 'where yarn') != 0) {
+                bat 'npm install -g yarn'
+              }
+              bat 'yarn install'
+            } else {
+              if (sh(returnStatus: true, script: 'which yarn') != 0) {
+                sh 'npm install -g yarn'
+              }
+              sh 'yarn install'
+           }
+           fingerprint 'package.json'
+            try {
+              if('windows'.equals(os)) {
+                bat 'yarn run coverage'
+              } else {
+                sh 'yarn run coverage'
+              }
+            } finally {
+              // record results even if tests/coverage 'fails'
+              junit 'junit.xml'
+            }
+          } // timeout
+        } // test
+      } // nodejs
+    }  // node
+  }
+}
+
+timestamps {
+  def isMaster = false
+  def packageVersion
+
+  node('osx || linux') {
+    stage('Checkout') {
+      // checkout scm
+      // Hack for JENKINS-37658 - see https://support.cloudbees.com/hc/en-us/articles/226122247-How-to-Customize-Checkout-for-Pipeline-Multibranch
+      // do a git clean before checking out
+      checkout([
+        $class: 'GitSCM',
+        branches: scm.branches,
+        extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
+        userRemoteConfigs: scm.userRemoteConfigs
+      ])
+
+      isMaster = env.BRANCH_NAME.equals('master')
+      packageVersion = jsonParse(readFile('package.json'))['version']
+      currentBuild.displayName = "#${packageVersion}-${currentBuild.number}"
+      stash name: 'sources', includes: '**', allowEmpty: true
+    }
+  }
+
+  stage('Test') {
+    parallel(
+      'Linux unit tests': unitTests('linux', nodeVersion),
+      'OSX unit tests': unitTests('osx', nodeVersion),
+      'Windows unit tests': unitTests('windows', nodeVersion),
+      failFast: false
+	)
+  } // Test
+
+} // timestamps

--- a/test/mocks/jdk-1.8-32bit/bin/javac
+++ b/test/mocks/jdk-1.8-32bit/bin/javac
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 while test $# -gt 0; do
-	if [[ "$1" = "-d64" ]]; then
+	if [ "$1" = "-d64" ]; then
 		exit 1
 	fi
 	shift

--- a/test/test-jdk.js
+++ b/test/test-jdk.js
@@ -1,6 +1,5 @@
 import JDK, { detect } from '../dist/index';
 
-import fs from 'fs';
 import path from 'path';
 import { exe } from 'appcd-subprocess';
 
@@ -26,11 +25,7 @@ describe('JDK', () => {
 	});
 
 	it('should error if dir is missing the JVM library', () => {
-		const mockDir = path.join(__dirname, 'mocks', 'empty');
-		if (!fs.existsSync(mockDir)) {
-			fs.mkdirSync(mockDir);
-		}
-		return detect(mockDir)
+		return detect(path.join(__dirname, 'mocks', 'empty'))
 			.then(() => {
 				throw new Error('Expected error');
 			}, err => {

--- a/test/test-jdk.js
+++ b/test/test-jdk.js
@@ -1,5 +1,6 @@
 import JDK, { detect } from '../dist/index';
 
+import fs from 'fs';
 import path from 'path';
 import { exe } from 'appcd-subprocess';
 
@@ -25,7 +26,11 @@ describe('JDK', () => {
 	});
 
 	it('should error if dir is missing the JVM library', () => {
-		return detect(path.join(__dirname, 'mocks', 'empty'))
+		const mockDir = path.join(__dirname, 'mocks', 'empty');
+		if (!fs.existsSync(mockDir)) {
+			fs.mkdirSync(mockDir);
+		}
+		return detect(mockDir)
 			.then(() => {
 				throw new Error('Expected error');
 			}, err => {


### PR DESCRIPTION
Part of https://jira.appcelerator.org/browse/DAEMON-202

This uses the Jenkins setup to run the unit tests across Linux, OSX and Windows, it only runs the tests. It does not publish the package for us, we could add that later if we wish. 

Additionally, this same setup will more than likely be used across androidlib, ioslib, jdklib and windowslib, so it would make make sense to migrate this into a common utils (I think the pipeline-library)

@cb1kenobi I changed two bits in the tests to get this passing,

- Made sure that the mocks/empty dir exists as it sometimes went missing when un-stashing sources on OSX and Windows
- Removed the bash builtin from the 1.8-32-bit javac mock